### PR TITLE
Fill in blanks enough to unblock the build.

### DIFF
--- a/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
+++ b/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
@@ -30,7 +30,7 @@ public class Robot implements Loggable {
     public Robot() {
         if (LIFT_CONNECTED) liftSubsystem = new LiftSubsystem(Hardware.liftMotor);
         if (DEPOSIT_CONNECTED) depositSubsystem = new DepositSubsystem(Hardware.leftDepositServo, Hardware.rightDepositServo);
-        if (DRIVE_CONNECTED) drivebaseSubsystem = new DrivebaseSubsystem(Hardware.flDriveMotor, Hardware.frDriveMotor, Hardware.rlDriveMotor, Hardware.rrDriveMotor);
+        if (DRIVE_CONNECTED) drivebaseSubsystem = new DrivebaseSubsystem(Hardware.flDriveMotor, Hardware.frDriveMotor, Hardware.rlDriveMotor, Hardware.rrDriveMotor, Hardware.imu);
         if (CAROUSEL_CONNECTED) carouselSubsystem = new CarouselSubsystem(Hardware.carouselMotor);
         if (INTAKE_CONNECTED) intakeSubsystem = new IntakeSubsystem(Hardware.intakeMotor);
         if (VISION_CONNECTED) visionSubsystem = new VisionSubsystem(Hardware.camera);

--- a/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/CarouselSubsystem.java
+++ b/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/CarouselSubsystem.java
@@ -1,4 +1,9 @@
 package org.firstinspires.ftc.teamcode.subsystems;
 
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.technototes.library.hardware.motor.Motor;
+
 public class CarouselSubsystem {
+  public CarouselSubsystem(Motor<DcMotorEx> m){}
+
 }

--- a/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/DrivebaseSubsystem.java
+++ b/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/DrivebaseSubsystem.java
@@ -2,8 +2,12 @@ package org.firstinspires.ftc.teamcode.subsystems;
 
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.technototes.library.hardware.motor.EncodedMotor;
+import com.technototes.library.hardware.sensor.IMU;
 import com.technototes.library.subsystem.Subsystem;
 
 public class DrivebaseSubsystem implements Subsystem {
+  public DrivebaseSubsystem(EncodedMotor<DcMotorEx> fl, EncodedMotor<DcMotorEx> fr,
+                            EncodedMotor<DcMotorEx> rl, EncodedMotor<DcMotorEx> rr,
+                            IMU i) {}
 
 }

--- a/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/IntakeSubsystem.java
+++ b/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/IntakeSubsystem.java
@@ -1,4 +1,9 @@
 package org.firstinspires.ftc.teamcode.subsystems;
 
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.technototes.library.hardware.motor.Motor;
+
 public class IntakeSubsystem {
+  public IntakeSubsystem(Motor<DcMotorEx> m) {
+  }
 }

--- a/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/VisionSubsystem.java
+++ b/TechnoTwoCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/VisionSubsystem.java
@@ -1,2 +1,25 @@
-package org.firstinspires.ftc.teamcode.subsystems;public class VisionSubsystem {
+package org.firstinspires.ftc.teamcode.subsystems;
+
+import com.technototes.vision.hardware.Camera;
+import com.technototes.vision.subsystem.PipelineSubsystem;
+
+import org.opencv.core.Mat;
+
+import java.util.function.Supplier;
+
+public class VisionSubsystem extends PipelineSubsystem implements Supplier<Integer> {
+
+  public VisionSubsystem(Camera c) {
+    super(c);
+  }
+
+  @Override
+  public Integer get() {
+    return null;
+  }
+
+  @Override
+  public Mat processFrame(Mat input) {
+    return null;
+  }
 }


### PR DESCRIPTION
This fills in (empty) implementations of the various subsystems, thus allowing RobotTwo code to properly build.