### PR TITLE
Add a simple command test, which shows that commands auto-restart

### DIFF
--- a/RobotLibrary/build.gradle
+++ b/RobotLibrary/build.gradle
@@ -24,14 +24,14 @@ dependencies {
 
     testImplementation(platform('org.junit:junit-bom:5.7.0'))
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.7.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.7.0')
     testImplementation('org.mockito:mockito-core:3.5.11')
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.7.0"
+}
 
-
+tasks.withType(Test) {
+    useJUnitPlatform()
 }
 
 repositories {

--- a/RobotLibrary/src/test/java/com/technototes/library/command/SimpleCommandTest.java
+++ b/RobotLibrary/src/test/java/com/technototes/library/command/SimpleCommandTest.java
@@ -1,0 +1,149 @@
+package com.technototes.library.command;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SimpleCommandTest {
+
+    static class InstantCommand implements Command {
+        public int initialized = 0;
+        public int executed = 0;
+        public int ended = 0;
+        public int canceled = 0;
+
+        @Override
+        public void init() {
+            initialized++;
+        }
+        @Override
+        public void execute() {
+            executed++;
+        }
+
+        @Override
+        public void end(boolean cancel) {
+            ended++;
+            if (cancel) {
+                canceled++;
+            }
+        }
+    }
+
+    @BeforeEach
+    public void setup(){
+        CommandScheduler.resetScheduler();
+    }
+
+    @Test
+    public void scheduleCommandNoCancel(){
+        InstantCommand command = new InstantCommand();
+
+        // Creating a command shouldn't cause it to be scheduled
+        CommandScheduler.getInstance().run();
+        assertEquals(0, command.initialized);
+        assertEquals(0, command.executed);
+        assertEquals(0, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().schedule(command);
+
+        // Scheduling a command won't cause it to run until after run()
+        assertEquals(0, command.initialized);
+        assertEquals(0, command.executed);
+        assertEquals(0, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+
+        // ?? The first run after scheduling a command doesn't do anything for the command
+        assertEquals(0, command.initialized);
+        assertEquals(0, command.executed);
+        assertEquals(0, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+
+        // ?? The second run after scheduling a command initializes the command
+        assertEquals(1, command.initialized);
+        assertEquals(0, command.executed);
+        assertEquals(0, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+
+        // The third run after scheduling a command finally runs it
+        assertEquals(1, command.initialized);
+        assertEquals(1, command.executed);
+        assertEquals(0, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+
+        // The fourth run after scheduling a 'one-shot' command finally ends it
+        assertEquals(1, command.initialized);
+        assertEquals(1, command.executed);
+        assertEquals(1, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+        // An ended command doesn't get scheduled anymore
+        assertEquals(1, command.initialized);
+        assertEquals(1, command.executed);
+        assertEquals(1, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+        // An ended command doesn't get scheduled anymore
+        // ?? But it does get initialized
+        assertEquals(2, command.initialized);
+        assertEquals(1, command.executed);
+        assertEquals(1, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+        // An ended command doesn't get scheduled anymore
+        // ?? But it does get initialized
+        // ?? And executed??
+        assertEquals(2, command.initialized);
+        assertEquals(2, command.executed);
+        assertEquals(1, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+        // An ended command doesn't get scheduled anymore
+        // ?? But it does get initialized
+        // ?? And executed??
+        // ?? And ends again?
+        assertEquals(2, command.initialized);
+        assertEquals(2, command.executed);
+        assertEquals(2, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+        assertEquals(2, command.initialized);
+        assertEquals(2, command.executed);
+        assertEquals(2, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+        assertEquals(3, command.initialized);
+        assertEquals(2, command.executed);
+        assertEquals(2, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+        assertEquals(3, command.initialized);
+        assertEquals(3, command.executed);
+        assertEquals(2, command.ended);
+        assertEquals(0, command.canceled);
+
+        CommandScheduler.getInstance().run();
+        assertEquals(3, command.initialized);
+        assertEquals(3, command.executed);
+        assertEquals(3, command.ended);
+        assertEquals(0, command.canceled);
+    }
+
+}


### PR DESCRIPTION
@1198159  - why does CommandScheduler.getInstance().schedule(command); cause the command to run over & over again after it finishes?